### PR TITLE
Remove module for colon regexp

### DIFF
--- a/checkstyle/src/main/resources/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle.xml
@@ -78,13 +78,6 @@
             <property name="classes" value="Boolean"/>
         </module>
         <module name="Regexp">
-            <property name="format" value="[^:^&quot;]:&quot; .*+"/>
-            <property name="message" value="check that a space is left after a colon on an assembled error message"/>
-            <property name="illegalPattern" value="true"/>
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment"
-                      value="check that a space is left after a colon with an assembled error message"/>
-        </module>
-        <module name="Regexp">
             <property name="format" value="[\r]?[\n][ \t]*[\r]?[\n][ \t]*[\r]?[\n][ \t]*"/>
             <property name="message" value="more than one blank line"/>
             <property name="illegalPattern" value="true"/>


### PR DESCRIPTION
This rule makes no sense, as this simple line will not pass Checkstyle:

```
private static final String ROOT = "http://localhost:" + System.getProperty("testPort");
```

unless we add a space ` ` character after the colon character:

```
private static final String ROOT = "http://localhost: " + System.getProperty("testPort");
```