### PR TITLE
Make the javadoc style optional for copyright header.

### DIFF
--- a/checkstyle-closed/src/main/resources/closedsource.java.header
+++ b/checkstyle-closed/src/main/resources/closedsource.java.header
@@ -1,4 +1,4 @@
-/\*\*
+/\*\*?
  \* Copyright \(c\) \d{4} by ArcBees Inc\., All rights reserved\.
  \* This source code, and resulting software, is the confidential and proprietary information
  \* \("Proprietary Information"\) and is the intellectual property \("Intellectual Property"\)

--- a/checkstyle/src/main/resources/opensource.java.header
+++ b/checkstyle/src/main/resources/opensource.java.header
@@ -1,4 +1,4 @@
-/\*\*
+/\*\*?
  \* Copyright \d{4} ArcBees Inc\.
  \*
  \* Licensed under the Apache License, Version 2\.0 \(the "License"\); you may not


### PR DESCRIPTION
In IntelliJ 14.1, when auto-format javadoc is enabled, it screws up the copyright header. Making the javadoc style optional for the copyrights regexp doesn't break old files while allowing new files to be updated.